### PR TITLE
Hidden command for Power On for shared resources

### DIFF
--- a/shell-definition.yaml
+++ b/shell-definition.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: tosca_simple_yaml_1_0
 metadata:
   template_name: Microsoft Azure Cloud Provider Shell 2G
   template_author: Quali
-  template_version: 2.3.0
+  template_version: 2.4.0
   template_icon: azure-icon.png
 
 description: >

--- a/src/driver.py
+++ b/src/driver.py
@@ -226,6 +226,13 @@ class AzureDriver(ResourceDriverInterface):
 
             return deploy_flow.deploy(request_actions=request_actions)
 
+    def PowerOnHidden(self, context, ports):
+        self.PowerOn(context, ports)
+        # set live status on deployed app if power on passed
+        api = CloudShellSessionContext(context).get_api()
+        resource = context.remote_endpoints[0]
+        api.SetResourceLiveStatus(resource.fullname, "Online", "Active")
+
     def PowerOn(self, context, ports):
         """Called when reserving a sandbox during setup.
 

--- a/src/drivermetadata.xml
+++ b/src/drivermetadata.xml
@@ -16,6 +16,7 @@
             <Command Description="" DisplayName="Set App Security Groups" Name="SetAppSecurityGroups" Tags="allow_unreserved" />
             <Command Description="" DisplayName="Get VmDetails" EnableCancellation="true" Name="GetVmDetails" Tags="allow_unreserved" />
             <Command Description="" DisplayName="Create Routetables" EnableCancellation="false" Name="CreateRouteTables" Tags="allow_unreserved" />
+            <Command Description="" DisplayName="Power On Hidden" Name="PowerOnHidden" Tags="remote_hidden_power_on,allow_shared" />
         </Category>
 
         <Category Name="Power">


### PR DESCRIPTION
I added a hidden command for Power On that to allow executing Power On on shared deployed apps. Its required for a use case at a customer.

The Power On command is executed on a deployed apps in the OOB setup like this:
_api.ExecuteResourceConnectedCommand(reservation_id, deployed_app_name, "PowerOn", "power")_

If the deployed app is a shared resource the server returns the following error:
Err code: Code 100
Err msg: 'Cannot execute \'PowerOn\' command on a shared resource. Unshare \'azure-ubuntu-5e49f917\' and try again.'

The new method is just a simple wrapper around the existing Power On command.
